### PR TITLE
fix: confine Cloud Convert output paths

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2022-2025 Splunk Inc.
+   Copyright (c) 2022-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: Cloud Convert
-Copyright (c) 2022-2025 Splunk Inc.
+Copyright (c) 2022-2026 Splunk Inc.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Cloud Convert
 
-Publisher: Splunk \
-Connector Version: 1.0.3 \
-Product Vendor: CloudConvert \
-Product Name: CloudConvert \
+Publisher: Splunk <br>
+Connector Version: 1.0.3 <br>
+Product Vendor: CloudConvert <br>
+Product Name: CloudConvert <br>
 Minimum Product Version: 6.1.0
 
 This app supports executing investigative and generic type of actions to convert the SOAR vault files to various formats
@@ -117,15 +117,15 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration \
-[convert file](#action-convert-file) - Convert one filetype to another \
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration <br>
+[convert file](#action-convert-file) - Convert one filetype to another <br>
 [get valid filetypes](#action-get-valid-filetypes) - Get a list of valid output file formats
 
 ## action: 'test connectivity'
 
 Validate the asset configuration for connectivity using supplied configuration
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -140,7 +140,7 @@ No Output
 
 Convert one filetype to another
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -171,7 +171,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Get a list of valid output file formats
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -197,7 +197,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2022-2025 Splunk Inc.
+# Copyright (c) 2022-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cloudconvert.json
+++ b/cloudconvert.json
@@ -10,7 +10,7 @@
     "python_version": "3.9, 3.13",
     "product_version_regex": ".*",
     "publisher": "Splunk",
-    "license": "Copyright (c) 2022-2025 Splunk Inc.",
+    "license": "Copyright (c) 2022-2026 Splunk Inc.",
     "app_version": "1.0.3",
     "utctime_updated": "2025-09-05T19:38:03.727850Z",
     "package_name": "phantom_cloudconvert",

--- a/cloudconvert_connector.py
+++ b/cloudconvert_connector.py
@@ -1,6 +1,6 @@
 # File: cloudconvert_connector.py
 #
-# Copyright (c) 2022-2025 Splunk Inc.
+# Copyright (c) 2022-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cloudconvert_connector.py
+++ b/cloudconvert_connector.py
@@ -18,6 +18,7 @@
 
 import json
 import os
+import re
 import time
 import uuid
 
@@ -38,6 +39,21 @@ from cloudconvert_consts import *
 class RetVal(tuple):
     def __new__(cls, val1, val2=None):
         return tuple.__new__(RetVal, (val1, val2))
+
+
+def _build_output_path(local_dir, filename, output_filetype):
+    if not re.fullmatch(r"[A-Za-z0-9]+(?:\.[A-Za-z0-9]+)*", output_filetype):
+        raise ValueError("Output filetype contains invalid characters")
+
+    safe_filename = os.path.basename(str(filename).replace("\\", "/"))
+    filename_stem = safe_filename.rsplit(".", 1)[0] or "converted_file"
+    output_filename = f"{filename_stem}.{output_filetype}"
+    real_local_dir = os.path.realpath(local_dir)
+    output_path = os.path.realpath(os.path.join(real_local_dir, output_filename))
+    if os.path.commonpath((real_local_dir, output_path)) != real_local_dir:
+        raise ValueError("Output path escapes the vault temporary directory")
+
+    return output_filename, output_path
 
 
 class CloudConvertConnector(BaseConnector):
@@ -383,7 +399,6 @@ class CloudConvertConnector(BaseConnector):
     def _get_converted_file(self, param, action_result, link, filename):
         url = link
         output_filetype = param["filetype"]
-        filename = filename.split(".")[0]
         self._stream_file_data = True
 
         ret_val, response = self._make_rest_call(url=url, action_result=action_result, method="get", empty_headers=True)
@@ -397,7 +412,10 @@ class CloudConvertConnector(BaseConnector):
             local_dir = f"{vault_tmp_dir}/{guid}"
         else:
             local_dir = os.path.join(paths.PHANTOM_VAULT, "tmp", guid)
-        output_filename = f"{filename}.{output_filetype}"
+        try:
+            output_filename, compressed_file_path = _build_output_path(local_dir, filename, output_filetype)
+        except ValueError as e:
+            return action_result.set_status(phantom.APP_ERROR, str(e)), None
 
         self.save_progress(f"Using temp directory: {guid}")
         self.debug_print(f"Using temp directory: {guid}")
@@ -408,8 +426,6 @@ class CloudConvertConnector(BaseConnector):
             return action_result.set_status(
                 phantom.APP_ERROR, "Unable to create temporary vault folder.", self._get_error_message_from_exception(e)
             ), None
-
-        compressed_file_path = f"{local_dir}/{output_filename}"
 
         # Try to stream the response to a file
         if response.status_code == 200:

--- a/cloudconvert_consts.py
+++ b/cloudconvert_consts.py
@@ -1,6 +1,6 @@
 # File: cloudconvert_consts.py
 #
-# Copyright (c) 2022-2025 Splunk Inc.
+# Copyright (c) 2022-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cloudconvert_get_valid_filetypes.html
+++ b/cloudconvert_get_valid_filetypes.html
@@ -11,7 +11,7 @@
 {% block widget_content %}
   <!-- Main Start Block -->
   <!-- File: cloudconvert_get_valid_filetypes.html
-  Copyright (c) 2022-2025 Splunk Inc.
+  Copyright (c) 2022-2026 Splunk Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/cloudconvert_view.py
+++ b/cloudconvert_view.py
@@ -1,6 +1,6 @@
 # File: cloudconvert_view.py
 #
-# Copyright (c) 2022-2025 Splunk Inc.
+# Copyright (c) 2022-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-- Validated output file types and confined converted files to the vault temporary directory.
+* - Validated output file types and confined converted files to the vault temporary directory.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* - Validated output file types and confined converted files to the vault temporary directory.
+* Validated output file types and confined converted files to the vault temporary directory.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+- Validated output file types and confined converted files to the vault temporary directory.


### PR DESCRIPTION
## Summary\n\n- reject output filetype values containing path separators or other unsafe characters\n- normalize the source name to a basename\n- verify the resolved output remains inside the per-run vault temporary directory\n\n## Tracking\n\n- [PAPP-38127](https://splunk.atlassian.net/browse/PAPP-38127)\n- [PSAAS-30987](https://splunk.atlassian.net/browse/PSAAS-30987)\n\n## Quality gate\n\n- pre-commit run --all-files\n- Python source compilation\n\nCreated with Codex AI assistance.

## Tracking

- PAPP: PAPP-38127
- PSAAS: PSAAS-30987
- Written by Codex.